### PR TITLE
Avoid to image duplicates.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,8 +37,10 @@ function setupLightboxesFromDOM() {
             source = document.getElementById(href.substring(1)) :
             source = href;
 
-        fsLightboxInstances[instanceName].props.sources.push(source);
-        fsLightboxInstances[instanceName].elements.a.push(a[i]);
+        if ( fsLightboxInstances[instanceName].props.sources.indexOf(source) === -1 ) {
+          fsLightboxInstances[instanceName].props.sources.push(source);
+          fsLightboxInstances[instanceName].elements.a.push(a[i]);
+        }
 
         const currentIndex = fsLightboxInstances[instanceName].props.sources.length - 1;
 


### PR DESCRIPTION
```html
<ul>
  <li class="portfolio-item">
    <a href="001.jpg" class="zoom-effect" data-fslightbox><i class="fa fa-zoom"></i></a>
    <a href="001.jpg" class="image-link" data-fslightbox>
      <img src="001-thumb.jpg" />
    </a>
  </li>
  <li class="portfolio-item">
    <a href="002.jpg" class="zoom-effect" data-fslightbox><i class="fa fa-zoom"></i></a>
    <a href="002.jpg" class="image-link" data-fslightbox>
      <img src="002-thumb.jpg" />
    </a>
  </li>
</ul>
```

Sometimes we need above markup style. In this usage 001 and 002 images shows twice (duplicates).

If you update these lines: https://github.com/banthagroup/fslightbox/blob/master/src/index.js#L39-L42 like this:

```js
if ( fsLightboxInstances[instanceName].props.sources.indexOf(source) === -1 ) {
  fsLightboxInstances[instanceName].props.sources.push(source);
  fsLightboxInstances[instanceName].elements.a.push(a[i]);
}
```

It solve and no issue.